### PR TITLE
Updates to the simcenterdocumentation.cls

### DIFF
--- a/EE-UQ/EEUQ-Document.tex
+++ b/EE-UQ/EEUQ-Document.tex
@@ -1,53 +1,12 @@
 \documentclass{simcenterdocumentation}
 \usepackage[backend=biber]{biblatex}
-\usepackage{hyperref}
-\hypersetup{
-    colorlinks,
-    citecolor=black,
-    filecolor=black,
-    linkcolor=black,
-    urlcolor=blue
-}
-
 \usepackage{subfig}
-\usepackage{listings,xcolor}
 \usepackage{multirow}
-\usepackage{adjustbox,lipsum}% to adjust table width
+\usepackage{adjustbox}
 
 %% SETTING ENVIRONMENT FOR PYTHON CODE SNIPPETS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 \usepackage[utf8]{inputenc}
-% Default fixed font does not support bold face
-\DeclareFixedFont{\ttb}{T1}{txtt}{bx}{n}{12} % for bold
-\DeclareFixedFont{\ttm}{T1}{txtt}{m}{n}{12}  % for normal
 
-% Custom colors
-\usepackage{color}
-\definecolor{deepblue}{rgb}{0,0,0.5}
-\definecolor{deepred}{rgb}{0.6,0,0}
-\definecolor{deepgreen}{rgb}{0,0.5,0}
-\usepackage{listings}
-
-% Python style for highlighting
-\newcommand\pythonstyle{\lstset{
-language=Python,
-basicstyle=\ttm,
-otherkeywords={self},             % Add keywords here
-keywordstyle=\ttb\color{deepblue},
-emph={MyClass,__init__},          % Custom highlighting
-emphstyle=\ttb\color{deepred},    % Custom highlighting style
-stringstyle=\color{deepgreen},
-frame=tb,                         % Any extra options here
-showstringspaces=false,            %
-breaklines=true
-}}
-
-% Python environment
-\lstnewenvironment{python}[1][]
-{
-\pythonstyle
-\lstset{#1}
-}
-{}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 
 % To compile this file, run "latex/pdflatex codedoc", then "biber codedoc"

--- a/Latex/DocumentationTemplate/chap1.tex
+++ b/Latex/DocumentationTemplate/chap1.tex
@@ -1,3 +1,36 @@
+\section{Brief overview of some functionality available in \texttt{simcenterdocumentation.cls}}
+You can access the software name, \getsoftwarename{}, like this
+\texttt{\textbackslash getsoftwarename\{\}} after it has been input in
+the preamble using \texttt{\textbackslash softwarename}. You can also
+get the \insertsurveylink{link} to the feedback survey and place it in
+the text using \texttt{\textbackslash insertsurveylink\{text\_for\_link\}}.
+
+\vspace{0.25cm}
+Code snippets with syntax highlighting can also be inserted:
+
+\begin{python}[caption=Python script for analyzing the portal frame model with uncertain parameters]
+  import numpy as np
+  import os
+  import shutil
+  import subprocess
+  from pyDOE import *
+  from scipy.stats.distributions import norm  
+#Setting number of samples
+nSamples = 1000
+
+#Creating latin hyper cube designs
+design = lhs(2, samples=nSamples)
+
+#Sampling Young's Modulus and Mass
+ESamples = norm(loc=4227, scale=500.0).ppf(design[:,0])
+mSamples = norm(loc=5.18, scale=1.0).ppf(design[:,1])
+\end{python}
+
+At present, this is only defined for \texttt{Python}, but can be easily extended in the class
+for other languages. This in \textbf{no way} indicates any preference for a particular coding language
+and should not be interpreted as a preference for \texttt{Python}.
+
+
 \section{Faceplate Marginalia}
 
 Invasive brag; gait grew Fuji Budweiser penchant walkover pus hafnium

--- a/Latex/DocumentationTemplate/codedoc.tex
+++ b/Latex/DocumentationTemplate/codedoc.tex
@@ -1,13 +1,5 @@
 \documentclass{simcenterdocumentation}
 \usepackage{biblatex}
-\usepackage{hyperref}
-\hypersetup{
-    colorlinks,
-    citecolor=black,
-    filecolor=black,
-    linkcolor=black,
-    urlcolor=black
-}
 
 % To compile this file, run "latex/pdflatex codedoc", then "biber codedoc"
 % (or "bibtex codedoc", if the output from latex asks for that instead),

--- a/Latex/LatexClass/simcenterdocumentation.cls
+++ b/Latex/LatexClass/simcenterdocumentation.cls
@@ -97,14 +97,15 @@
 \fi
 
 % Now load the memoir class, and configure it appropriately.
-
 \LoadClass{memoir}
 \RequirePackage{graphicx}
 \RequirePackage{titlesec}
+\RequirePackage{hyperref}
+\RequirePackage{xcolor}
+\RequirePackage{listings}
 
-% Remove chapter name and number from chapter titles
-\titleformat{\chapter}[display]
-  {\normalfont\bfseries}{}{0pt}{\Huge}
+% Set section numbering depth. Depth of 3 sets numbering to go up to and including subsubsection
+\setcounter{secnumdepth}{3}
 
 \setlrmarginsandblock{1in}{*}{*}
   \@tempdima=1in  \advance\@tempdima 25pt \advance\@tempdima\normalbaselineskip
@@ -182,7 +183,50 @@
 
 \let\memoirlistoftables=\listoftables
 \renewcommand\listoftables{\begin{SingleSpace}\memoirlistoftables
-  \end{SingleSpace}}
+\end{SingleSpace}}
+
+%%% THIS SECTION DECLARES ENVIRONMENTS FOR CODE SNIPPETS AND ALLOWS FOR SYNTAX HIGHLIGHTING %%%%%%%%%%%%%%%%%%%%
+% Set link colors 
+\hypersetup{
+    colorlinks,
+    citecolor=black,
+    filecolor=black,
+    linkcolor=black,
+    urlcolor=blue
+}
+
+% Default fixed font does not support bold face
+\DeclareFixedFont{\ttb}{T1}{txtt}{bx}{n}{12} % for bold
+\DeclareFixedFont{\ttm}{T1}{txtt}{m}{n}{12}  % for normal
+
+% Custom colors for code snippets
+\definecolor{deepblue}{rgb}{0,0,0.5}
+\definecolor{deepred}{rgb}{0.6,0,0}
+\definecolor{deepgreen}{rgb}{0,0.5,0}
+
+% Python style for highlighting
+\newcommand\pythonstyle{\lstset{
+language=Python,
+basicstyle=\ttm,
+otherkeywords={self},             % Add keywords here
+keywordstyle=\ttb\color{deepblue},
+emph={MyClass,__init__},          % Custom highlighting
+emphstyle=\ttb\color{deepred},    % Custom highlighting style
+stringstyle=\color{deepgreen},
+frame=tb,                         % Any extra options here
+showstringspaces=false,            %
+breaklines=true
+}}
+
+% Python environment
+\lstnewenvironment{python}[1][]
+{
+\pythonstyle
+\lstset{#1}
+}
+{}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %  draft option (this is where the draft option is actually implemented)
 %
@@ -202,12 +246,16 @@
 
 % The software name
 \def\softwarename#1{\gdef\@softwarename{#1}}
+\def\getsoftwarename{\@softwarename}
 
 % The software version
 \def\softwareversion#1{\gdef\@softwareversion{#1}}
 
 % Institutions
 \def\institutions#1{\gdef\@institutions{#1}}
+
+% Function for getting link to feedback survey
+\def\insertsurveylink#1{\href{https://docs.google.com/forms/d/e/1FAIpQLSfh20kBxDmvmHgz9uFwhkospGLCeazZzL770A2GuYZ2KgBZBA/viewform?usp=sf_link}{\color{blue}{#1}}}
 
 % The alwayssingle environment ensures that front matter is always
 % single column even in a double-column document.


### PR DESCRIPTION
This pull request adds the following functionality to `simcenterdocumentation.cls`:
* Macro `\getsoftwarename{}` to get software name
- Macro `\insertsurveylink{named_link}` to get named link to user's survey
- Code snippets with colored syntax using `listings`--just `Python` right now
- Link colors are set in `.cls` file so they are the same across packages