### PR TITLE
Please merge: Fix NSF grant number

### DIFF
--- a/docs/common/front-matter/desktop/ack.rst
+++ b/docs/common/front-matter/desktop/ack.rst
@@ -4,4 +4,4 @@
 Acknowledgments
 ***************
 
-This material is based upon work supported by the U.S. National Science Foundation under Grants No. 1621843 and No. 2131111. Any opinions, findings, conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the U.S. National Science Foundation.
+This material is based upon work supported by the U.S. National Science Foundation under Grants No. 1612843 and No. 2131111. Any opinions, findings, conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the U.S. National Science Foundation.

--- a/docs/common/front-matter/desktop/ack_pbe.rst
+++ b/docs/common/front-matter/desktop/ack_pbe.rst
@@ -8,7 +8,7 @@ Acknowledgments
 National Science Foundation
 ---------------------------
 
-This material is based upon work supported by the U.S. National Science Foundation under Grants No. 1621843 and No. 2131111. Any opinions, findings, conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the U.S. National Science Foundation.
+This material is based upon work supported by the U.S. National Science Foundation under Grants No. 1612843 and No. 2131111. Any opinions, findings, conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the U.S. National Science Foundation.
 
 ------------
 Contributors


### PR DESCRIPTION
Wrong grant number on  basically every app's documentation. This is on the second page of the documentation, so its pretty visibile.

Should be: 1612843
Was: 1621843

https://www.nsf.gov/awardsearch/showAward?AWD_ID=1612843